### PR TITLE
Add label and description fields to cube model

### DIFF
--- a/babbage/schema/model.json
+++ b/babbage/schema/model.json
@@ -5,6 +5,8 @@
     "format": "valid_hierarchies",
 
     "properties": {
+        "label": {"$ref": "#/definitions/label"},
+        "description": {"$ref": "#/definitions/description"},
         "fact_table": {"$ref": "#/definitions/table"},
         "measures": {"$ref": "#/definitions/measures"},
         "dimensions": {"$ref": "#/definitions/dimensions"},


### PR DESCRIPTION
Only added to schema so long to hear if you think it's a decent idea.

The actual idea is to have this returned along with cube name under `/cubes`