### PR TITLE
Star tables

### DIFF
--- a/babbage/cube.py
+++ b/babbage/cube.py
@@ -3,6 +3,7 @@ from sqlalchemy.schema import Table
 from sqlalchemy.sql.expression import select
 
 from babbage.model import Model
+from babbage.model.dimension import Dimension
 from babbage.query import count_results, generate_results, first_result
 from babbage.query import Cuts, Drilldowns, Fields, Ordering, Aggregates
 from babbage.query import Pagination
@@ -60,15 +61,18 @@ class Cube(object):
         aggregates, grouped by a given set of drilldown dimensions (i.e.
         dividers). The query can also be filtered and sorted. """
         q = select()
-        cuts, q = Cuts(self).apply(q, cuts)
-        aggregates, q = Aggregates(self).apply(q, aggregates)
+        bindings = []
+        cuts, q, bindings = Cuts(self).apply(q, bindings, cuts)
+        aggregates, q, bindings = Aggregates(self).apply(q, bindings, aggregates)
         summary = first_result(self, q)
 
-        attributes, q = Drilldowns(self).apply(q, drilldowns)
+        attributes, q, bindings = Drilldowns(self).apply(q, bindings, drilldowns)
+        q = self.restrict_joins(q, bindings)
         count = count_results(self, q)
 
         page, q = Pagination(self).apply(q, page, page_size)
-        ordering, q = Ordering(self).apply(q, order)
+        ordering, q, bindings = Ordering(self).apply(q, bindings, order)
+        q = self.restrict_joins(q, bindings)
         return {
             'total_cell_count': count,
             'cells': list(generate_results(self, q)),
@@ -86,12 +90,15 @@ class Cube(object):
         paginated. If the reference describes a dimension, all attributes are
         returned. """
         q = select(distinct=True)
-        cuts, q = Cuts(self).apply(q, cuts)
-        fields, q = Fields(self).apply(q, ref)
-        ordering, q = Ordering(self).apply(q, order)
+        bindings = []
+        cuts, q, bindings = Cuts(self).apply(q, bindings, cuts)
+        fields, q, bindings = Fields(self).apply(q, bindings, ref)
+        ordering, q, bindings = Ordering(self).apply(q, bindings, order)
+        q = self.restrict_joins(q, bindings)
         count = count_results(self, q)
 
         page, q = Pagination(self).apply(q, page, page_size)
+        q = self.restrict_joins(q, bindings)
         return {
             'total_member_count': count,
             'data': list(generate_results(self, q)),
@@ -106,13 +113,16 @@ class Cube(object):
               page_size=None):
         """ List all facts in the cube, returning only the specified references
         if these are specified. """
-        q = select()
-        cuts, q = Cuts(self).apply(q, cuts)
-        fields, q = Fields(self).apply(q, fields)
+        q = select().select_from(self.fact_table)
+        bindings = []
+        cuts, q, bindings = Cuts(self).apply(q, bindings, cuts)
+        fields, q, bindings = Fields(self).apply(q, bindings, fields)
+        q = self.restrict_joins(q, bindings)
         count = count_results(self, q)
 
-        ordering, q = Ordering(self).apply(q, order)
+        ordering, q, bindings = Ordering(self).apply(q, bindings, order)
         page, q = Pagination(self).apply(q, page, page_size)
+        q = self.restrict_joins(q, bindings)
         return {
             'total_fact_count': count,
             'data': list(generate_results(self, q)),
@@ -130,6 +140,38 @@ class Cube(object):
         for dimension in self.model.dimensions:
             result = self.members(dimension.ref, page_size=0)
             dimension.spec['cardinality'] = result.get('total_member_count')
+
+    def restrict_joins(self, q, bindings):
+        """
+        Restrict the joins across all tables referenced in the database
+        query to those specified in the model for the relevant dimensions.
+        If a single table is used for the query, no unnecessary joins are
+        performed. If more than one table are referenced, this ensures
+        their returned rows are connected via the fact table.
+        """
+        if len(q.froms) == 1:
+            return q
+        else:
+            for binding in bindings:
+                if binding.table == self.fact_table:
+                    continue
+                concept = self.model[binding.ref]
+                if isinstance(concept, Dimension):
+                    dimension = concept
+                else:
+                    dimension = concept.dimension
+                dimension_table, key_column = dimension.key_attribute.bind(self)
+                if binding.table != dimension_table:
+                    raise BindingException('Attributes must be of same table as '
+                                           'as their dimension key')
+                try:
+                    join_column = self.fact_table.columns[dimension.join_column_name]
+                except KeyError:
+                    raise BindingException("Join column '%s' for %r not in fact table."
+                                           % (dimension.join_column_name, dimension))
+
+                q = q.where(join_column == key_column)
+        return q
 
     def __repr__(self):
         return '<Cube(%r)' % self.name

--- a/babbage/cube.py
+++ b/babbage/cube.py
@@ -64,6 +64,7 @@ class Cube(object):
         bindings = []
         cuts, q, bindings = Cuts(self).apply(q, bindings, cuts)
         aggregates, q, bindings = Aggregates(self).apply(q, bindings, aggregates)
+        q = self.restrict_joins(q, bindings)
         summary = first_result(self, q)
 
         attributes, q, bindings = Drilldowns(self).apply(q, bindings, drilldowns)

--- a/babbage/model/binding.py
+++ b/babbage/model/binding.py
@@ -1,0 +1,10 @@
+class Binding(object):
+    def __init__(self, table, ref):
+        self.table = table
+        self.ref = ref
+
+    def __unicode__(self):
+        return u"<Binding(%r, %r)>" % (self.table.name, self.ref)
+
+    def __repr__(self):
+        return self.__unicode__()

--- a/babbage/model/dimension.py
+++ b/babbage/model/dimension.py
@@ -10,6 +10,7 @@ class Dimension(Concept):
     def __init__(self, model, name, spec, hierarchy=None):
         super(Dimension, self).__init__(model, name, spec)
         self.hierarchy = hierarchy if hierarchy is not None else self.name
+        self.join_column_name = spec.get('join_column')
 
     @property
     def attributes(self):

--- a/babbage/model/dimension.py
+++ b/babbage/model/dimension.py
@@ -1,5 +1,6 @@
 from babbage.model.concept import Concept
 from babbage.model.attribute import Attribute
+from babbage.exc import BindingException
 
 
 class Dimension(Concept):
@@ -29,6 +30,8 @@ class Dimension(Concept):
         for attr in self.attributes:
             if attr.name == self.spec.get('key_attribute'):
                 return attr
+        raise BindingException("key_attribute '%s' not found in dimension '%s'"
+                               % (self.spec.get('key_attribute'), self.name))
 
     @property
     def cardinality(self):

--- a/babbage/query/aggregates.py
+++ b/babbage/query/aggregates.py
@@ -17,7 +17,7 @@ class Aggregates(Parser):
         for aggregate in self.parse(aggregates):
             info.append(aggregate)
             table, column = self.cube.model[aggregate].bind(self.cube)
-            q = self.ensure_table(q, table)
+            self.add_binding(table, aggregate)
             q = q.column(column)
 
         if not len(self.results):
@@ -25,6 +25,7 @@ class Aggregates(Parser):
             for aggregate in self.cube.model.aggregates:
                 info.append(aggregate.ref)
                 table, column = aggregate.bind(self.cube)
-                q = self.ensure_table(q, table)
+                self.add_binding(table, aggregate.ref)
                 q = q.column(column)
+        q = self.restrict_joins(q)
         return info, q

--- a/babbage/query/aggregates.py
+++ b/babbage/query/aggregates.py
@@ -1,4 +1,5 @@
 from babbage.query.parser import Parser
+from babbage.model.binding import Binding
 from babbage.exc import QueryException
 
 
@@ -12,12 +13,12 @@ class Aggregates(Parser):
             raise QueryException('Invalid aggregate: %r' % ast)
         self.results.append(ast)
 
-    def apply(self, q, aggregates):
+    def apply(self, q, bindings, aggregates):
         info = []
         for aggregate in self.parse(aggregates):
             info.append(aggregate)
             table, column = self.cube.model[aggregate].bind(self.cube)
-            self.add_binding(table, aggregate)
+            bindings.append(Binding(table, aggregate))
             q = q.column(column)
 
         if not len(self.results):
@@ -25,7 +26,6 @@ class Aggregates(Parser):
             for aggregate in self.cube.model.aggregates:
                 info.append(aggregate.ref)
                 table, column = aggregate.bind(self.cube)
-                self.add_binding(table, aggregate.ref)
+                bindings.append(Binding(table, aggregate.ref))
                 q = q.column(column)
-        q = self.restrict_joins(q)
-        return info, q
+        return info, q, bindings

--- a/babbage/query/cuts.py
+++ b/babbage/query/cuts.py
@@ -2,6 +2,7 @@ import six
 from sqlalchemy import type_coerce
 
 from babbage.query.parser import Parser
+from babbage.model.binding import Binding
 from babbage.exc import QueryException
 
 
@@ -18,7 +19,7 @@ class Cuts(Parser):
             raise QueryException('Invalid cut: %r' % ast[0])
         self.results.append((ast[0], ast[1], value))
 
-    def apply(self, q, cuts):
+    def apply(self, q, bindings, cuts):
         """ Apply a set of filters, which can be given as a set of tuples in
         the form (ref, operator, value), or as a string in query form. If it
         is ``None``, no filter will be applied. """
@@ -26,7 +27,6 @@ class Cuts(Parser):
         for (ref, operator, value) in self.parse(cuts):
             info.append({'ref': ref, 'operator': operator, 'value': value})
             table, column = self.cube.model[ref].bind(self.cube)
-            self.add_binding(table, ref)
+            bindings.append(Binding(table, ref))
             q = q.where(column == type_coerce(value, column.type))
-        q = self.restrict_joins(q)
-        return info, q
+        return info, q, bindings

--- a/babbage/query/cuts.py
+++ b/babbage/query/cuts.py
@@ -26,6 +26,7 @@ class Cuts(Parser):
         for (ref, operator, value) in self.parse(cuts):
             info.append({'ref': ref, 'operator': operator, 'value': value})
             table, column = self.cube.model[ref].bind(self.cube)
-            q = self.ensure_table(q, table)
+            self.add_binding(table, ref)
             q = q.where(column == type_coerce(value, column.type))
+        q = self.restrict_joins(q)
         return info, q

--- a/babbage/query/drilldowns.py
+++ b/babbage/query/drilldowns.py
@@ -1,4 +1,5 @@
 from babbage.query.parser import Parser
+from babbage.model.binding import Binding
 from babbage.exc import QueryException
 
 
@@ -14,15 +15,14 @@ class Drilldowns(Parser):
         if ast not in self.results:
             self.results.append(ast)
 
-    def apply(self, q, drilldowns):
+    def apply(self, q, bindings, drilldowns):
         """ Apply a set of grouping criteria and project them. """
         info = []
         for drilldown in self.parse(drilldowns):
             for attribute in self.cube.model.match(drilldown):
                 info.append(attribute.ref)
                 table, column = attribute.bind(self.cube)
-                self.add_binding(table, attribute.ref)
+                bindings.append(Binding(table, attribute.ref))
                 q = q.column(column)
                 q = q.group_by(column)
-        q = self.restrict_joins(q)
-        return info, q
+        return info, q, bindings

--- a/babbage/query/drilldowns.py
+++ b/babbage/query/drilldowns.py
@@ -21,7 +21,8 @@ class Drilldowns(Parser):
             for attribute in self.cube.model.match(drilldown):
                 info.append(attribute.ref)
                 table, column = attribute.bind(self.cube)
-                q = self.ensure_table(q, table)
+                self.add_binding(table, attribute.ref)
                 q = q.column(column)
                 q = q.group_by(column)
+        q = self.restrict_joins(q)
         return info, q

--- a/babbage/query/fields.py
+++ b/babbage/query/fields.py
@@ -22,7 +22,7 @@ class Fields(Parser):
             for concept in self.cube.model.match(field):
                 info.append(concept.ref)
                 table, column = concept.bind(self.cube)
-                q = self.ensure_table(q, table)
+                self.add_binding(table, concept.ref)
                 q = q.column(column)
 
         if not len(self.results):
@@ -31,6 +31,7 @@ class Fields(Parser):
                     list(self.cube.model.measures):
                 info.append(concept.ref)
                 table, column = concept.bind(self.cube)
-                q = self.ensure_table(q, table)
+                self.add_binding(table, concept.ref)
                 q = q.column(column)
+        q = self.restrict_joins(q)
         return info, q

--- a/babbage/query/fields.py
+++ b/babbage/query/fields.py
@@ -1,4 +1,5 @@
 from babbage.query.parser import Parser
+from babbage.model.binding import Binding
 from babbage.exc import QueryException
 
 
@@ -15,14 +16,14 @@ class Fields(Parser):
             raise QueryException('Invalid field: %r' % ast)
         self.results.append(ast)
 
-    def apply(self, q, fields):
+    def apply(self, q, bindings, fields):
         """ Define a set of fields to return for a non-aggregated query. """
         info = []
         for field in self.parse(fields):
             for concept in self.cube.model.match(field):
                 info.append(concept.ref)
                 table, column = concept.bind(self.cube)
-                self.add_binding(table, concept.ref)
+                bindings.append(Binding(table, concept.ref))
                 q = q.column(column)
 
         if not len(self.results):
@@ -31,7 +32,6 @@ class Fields(Parser):
                     list(self.cube.model.measures):
                 info.append(concept.ref)
                 table, column = concept.bind(self.cube)
-                self.add_binding(table, concept.ref)
+                bindings.append(Binding(table, concept.ref))
                 q = q.column(column)
-        q = self.restrict_joins(q)
-        return info, q
+        return info, q, bindings

--- a/babbage/query/ordering.py
+++ b/babbage/query/ordering.py
@@ -1,6 +1,7 @@
 import six
 
 from babbage.query.parser import Parser
+from babbage.model.binding import Binding
 from babbage.exc import QueryException
 
 
@@ -18,7 +19,7 @@ class Ordering(Parser):
             raise QueryException('Invalid sorting criterion: %r' % ast)
         self.results.append((ref, direction))
 
-    def apply(self, q, ordering):
+    def apply(self, q, bindings, ordering):
         """ Sort on a set of field specifications of the type (ref, direction)
         in order of the submitted list. """
         info = []
@@ -26,7 +27,7 @@ class Ordering(Parser):
             info.append((ref, direction))
             table, column = self.cube.model[ref].bind(self.cube)
             column = column.asc() if direction == 'asc' else column.desc()
-            self.add_binding(table, ref)
+            bindings.append(Binding(table, ref))
             if self.cube.is_postgresql:
                 column = column.nullslast()
             q = q.order_by(column)
@@ -37,5 +38,4 @@ class Ordering(Parser):
                 if self.cube.is_postgresql:
                     column = column.nullslast()
                 q = q.order_by(column)
-        q = self.restrict_joins(q)
-        return info, q
+        return info, q, bindings

--- a/babbage/query/ordering.py
+++ b/babbage/query/ordering.py
@@ -26,7 +26,7 @@ class Ordering(Parser):
             info.append((ref, direction))
             table, column = self.cube.model[ref].bind(self.cube)
             column = column.asc() if direction == 'asc' else column.desc()
-            q = self.ensure_table(q, table)
+            self.add_binding(table, ref)
             if self.cube.is_postgresql:
                 column = column.nullslast()
             q = q.order_by(column)
@@ -37,4 +37,5 @@ class Ordering(Parser):
                 if self.cube.is_postgresql:
                     column = column.nullslast()
                 q = q.order_by(column)
+        q = self.restrict_joins(q)
         return info, q

--- a/babbage/query/parser.py
+++ b/babbage/query/parser.py
@@ -6,7 +6,7 @@ import six
 import dateutil.parser
 from grako.exceptions import GrakoException
 
-from babbage.exc import QueryException
+from babbage.exc import QueryException, BindingException
 from babbage.util import SCHEMA_PATH
 
 
@@ -22,6 +22,15 @@ class Parser(object):
     def __init__(self, cube):
         self.results = []
         self.cube = cube
+        self.bindings = []
+
+    def add_binding(self, table, ref):
+        """
+        Record an attribute binding in the current parse.
+        Must be called by each parser instance for each column
+        used in the database query.
+        """
+        self.bindings.append(Binding(table, ref))
 
     def string_value(self, ast):
         text = ast[0]
@@ -46,11 +55,40 @@ class Parser(object):
             text = []
         return text
 
-    def ensure_table(self, q, table):
-        if table not in q.froms:
-            q = q.select_from(table)
+    def restrict_joins(self, q):
+        """
+        Restrict the joins across all tables referenced in the database
+        query to those specified in the model for the relevant dimensions.
+        If a single table is used for the query, no unnecessary joins are
+        performed. If more than one table are referenced, this ensures
+        their returned rows are connected via the fact table.
+        """
+        if len(q.froms) == 1:
+            return q
+        else:
+            for binding in self.bindings:
+                if binding.table == self.cube.fact_table:
+                    continue
+                concept = self.cube.model[binding.ref]
+                dimension = concept.dimension  # assume concept is an attribute
+                dimension_table, key_column = dimension.key_attribute.bind(self.cube)
+                if binding.table != dimension_table:
+                    raise BindingException('Attributes must be of same table as '
+                                           'as their dimension key')
+                try:
+                    join_column = self.cube.fact_table.columns[dimension.join_column_name]
+                except KeyError:
+                    raise BindingException("Join column '%s' for %r not in fact table."
+                                           % (dimension.join_column_name, dimension))
+                q = q.where(join_column == key_column)
         return q
 
     @staticmethod
     def allrefs(*args):
         return [ref for concept_list in args for concept in concept_list for ref in concept.refs]
+
+
+class Binding(object):
+    def __init__(self, table, ref):
+        self.table = table
+        self.ref = ref

--- a/babbage/query/parser.py
+++ b/babbage/query/parser.py
@@ -6,9 +6,8 @@ import six
 import dateutil.parser
 from grako.exceptions import GrakoException
 
-from babbage.exc import QueryException, BindingException
+from babbage.exc import QueryException
 from babbage.util import SCHEMA_PATH
-from babbage.model.dimension import Dimension
 
 
 with open(os.path.join(SCHEMA_PATH, 'parser.ebnf'), 'rb') as fh:
@@ -24,14 +23,6 @@ class Parser(object):
         self.results = []
         self.cube = cube
         self.bindings = []
-
-    def add_binding(self, table, ref):
-        """
-        Record an attribute binding in the current parse.
-        Must be called by each parser instance for each column
-        used in the database query.
-        """
-        self.bindings.append(Binding(table, ref))
 
     def string_value(self, ast):
         text = ast[0]
@@ -56,43 +47,6 @@ class Parser(object):
             text = []
         return text
 
-    def restrict_joins(self, q):
-        """
-        Restrict the joins across all tables referenced in the database
-        query to those specified in the model for the relevant dimensions.
-        If a single table is used for the query, no unnecessary joins are
-        performed. If more than one table are referenced, this ensures
-        their returned rows are connected via the fact table.
-        """
-        if len(q.froms) == 1:
-            return q
-        else:
-            for binding in self.bindings:
-                if binding.table == self.cube.fact_table:
-                    continue
-                concept = self.cube.model[binding.ref]
-                if isinstance(concept, Dimension):
-                    dimension = concept
-                else:
-                    dimension = concept.dimension
-                dimension_table, key_column = dimension.key_attribute.bind(self.cube)
-                if binding.table != dimension_table:
-                    raise BindingException('Attributes must be of same table as '
-                                           'as their dimension key')
-                try:
-                    join_column = self.cube.fact_table.columns[dimension.join_column_name]
-                except KeyError:
-                    raise BindingException("Join column '%s' for %r not in fact table."
-                                           % (dimension.join_column_name, dimension))
-                q = q.where(join_column == key_column)
-        return q
-
     @staticmethod
     def allrefs(*args):
         return [ref for concept_list in args for concept in concept_list for ref in concept.refs]
-
-
-class Binding(object):
-    def __init__(self, table, ref):
-        self.table = table
-        self.ref = ref

--- a/babbage/query/parser.py
+++ b/babbage/query/parser.py
@@ -8,6 +8,7 @@ from grako.exceptions import GrakoException
 
 from babbage.exc import QueryException, BindingException
 from babbage.util import SCHEMA_PATH
+from babbage.model.dimension import Dimension
 
 
 with open(os.path.join(SCHEMA_PATH, 'parser.ebnf'), 'rb') as fh:
@@ -70,7 +71,10 @@ class Parser(object):
                 if binding.table == self.cube.fact_table:
                     continue
                 concept = self.cube.model[binding.ref]
-                dimension = concept.dimension  # assume concept is an attribute
+                if isinstance(concept, Dimension):
+                    dimension = concept
+                else:
+                    dimension = concept.dimension
                 dimension_table, key_column = dimension.key_attribute.bind(self.cube)
                 if binding.table != dimension_table:
                     raise BindingException('Attributes must be of same table as '

--- a/tests/fixtures/cap_or_cur.csv
+++ b/tests/fixtures/cap_or_cur.csv
@@ -1,0 +1,3 @@
+code,label
+CAP,"Capital Expenditure"
+CUR,"Current Expenditure"

--- a/tests/fixtures/models/cra.json
+++ b/tests/fixtures/models/cra.json
@@ -3,14 +3,21 @@
     "dimensions": {
         "cap_or_cur": {
             "attributes": {
-                "cap_or_cur": {
-                    "column": "cap_or_cur",
-                    "label": "Label"
+                "code": {
+                    "column": "cap_or_cur.code",
+                    "label": "Label",
+                    "type": "string"
+                },
+                "label": {
+                    "column": "cap_or_cur.label",
+                    "label": "Label",
+                    "type": "string"
                 }
             },
-            "key_attribute": "cap_or_cur",
+            "key_attribute": "code",
             "description": "Central government, local government or public corporation",
-            "label": "CG, LG or PC"
+            "label": "CG, LG or PC",
+            "join_column": "cap_or_cur"
         },
         "cofog1": {
             "attributes": {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,6 +15,7 @@ class CubeManagerTestCase(TestCase):
         path = os.path.join(FIXTURE_PATH, 'models')
         self.mgr = JSONCubeManager(self.engine, path)
         self.cra_table = load_csv('cra.csv')
+        self.cra_table = load_csv('cap_or_cur.csv')
         configure_api(self.app, self.mgr)
 
     def test_index(self):
@@ -68,14 +69,14 @@ class CubeManagerTestCase(TestCase):
 
     def test_facts_simple(self):
         res = self.client.get(url_for('babbage_api.facts', name='cra'))
-        assert res.status_code == 200, res
+        assert res.status_code == 200, (res, res.get_data())
         assert 'total_fact_count' in res.json, res.json
         assert 36 == len(res.json['data']), res.json
 
     def test_facts_cut(self):
         res = self.client.get(url_for('babbage_api.facts', name='cra',
                                       cut='cofog1:"10"'))
-        assert res.status_code == 200, res
+        assert res.status_code == 200, (res, res.get_data())
         assert 11 == len(res.json['data']), len(res.json['data'])
 
     def test_members_missing(self):

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -12,6 +12,7 @@ class CubeTestCase(TestCase):
         super(CubeTestCase, self).setUp()
         self.cra_model = load_json_fixture('models/cra.json')
         self.cra_table = load_csv('cra.csv')
+        self.cra_table = load_csv('cap_or_cur.csv')
         self.cube = Cube(self.engine, 'cra', self.cra_model)
 
     def test_table_exists(self):

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -191,6 +191,16 @@ class CubeTestCase(TestCase):
         assert 'amount.sum' not in row0, row0
         assert 'amount' not in row0, row0
 
+    def test_aggregate_star_count_only(self):
+        aggs = self.cube.aggregate(drilldowns='cap_or_cur',
+                                   order='cap_or_cur',
+                                   aggregates='_count')
+        assert aggs['total_cell_count'] == 2, aggs
+        assert len(aggs['cells']) == 2, len(aggs['data'])
+        row0 = aggs['cells'][0]
+        assert row0['cap_or_cur.code'] == 'CAP', row0
+        assert row0['_count'] == 15, row0
+
     def test_aggregate_empty(self):
         aggs = self.cube.aggregate(drilldowns='cofog1', page_size=0)
         assert aggs['total_cell_count'] == 4, aggs['total_cell_count']

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -78,6 +78,24 @@ class CubeTestCase(TestCase):
         assert facts['total_fact_count'] == 21, facts
         assert len(facts['data']) == 21, len(facts['data'])
 
+    def test_facts_star_filter_and_facts_field(self):
+        facts = self.cube.facts(cuts='cap_or_cur.label:"Current Expenditure"',
+                                fields='cofog1')
+        assert facts['total_fact_count'] == 21, facts
+        assert len(facts['data']) == 21, len(facts['data'])
+
+    def test_facts_star_filter_and_field(self):
+        facts = self.cube.facts(cuts='cap_or_cur.label:"Current Expenditure"',
+                                fields='cap_or_cur.code')
+        assert facts['total_fact_count'] == 21, facts
+        assert len(facts['data']) == 21, len(facts['data'])
+
+    def test_facts_facts_filter_and_star_field(self):
+        facts = self.cube.facts(cuts='cofog1:"4"',
+                                fields='cap_or_cur.code')
+        assert facts['total_fact_count'] == 12, facts
+        assert len(facts['data']) == 12, len(facts['data'])
+
     @raises(QueryException)
     def test_facts_invalid_filter(self):
         self.cube.facts(cuts='cofogXX:"4"')

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -37,6 +37,20 @@ class CubeTestCase(TestCase):
         self.cube = Cube(self.engine, 'cra', model)
         self.cube.model['cofog1.name'].bind(self.cube)
 
+    @raises(BindingException)
+    def test_star_column_nonexist(self):
+        model = self.cra_model.copy()
+        model['dimensions']['cap_or_cur']['join_column'] = 'lala'
+        self.cube = Cube(self.engine, 'cra', model)
+        self.cube.facts()
+
+    @raises(BindingException)
+    def test_attr_table_different_from_dimension_key(self):
+        model = self.cra_model.copy()
+        model['dimensions']['cap_or_cur']['attributes']['code']['column'] = 'cap_or_cur'
+        self.cube = Cube(self.engine, 'cra', model)
+        self.cube.facts()
+
     def test_dimension_column_qualified(self):
         model = self.cra_model.copy()
         name = 'cra.cofog1_name'
@@ -59,6 +73,11 @@ class CubeTestCase(TestCase):
         assert facts['total_fact_count'] == 12
         assert len(facts['data']) == 12, len(facts['data'])
 
+    def test_facts_star_filter(self):
+        facts = self.cube.facts(cuts='cap_or_cur.label:"Current Expenditure"')
+        assert facts['total_fact_count'] == 21, facts
+        assert len(facts['data']) == 21, len(facts['data'])
+
     @raises(QueryException)
     def test_facts_invalid_filter(self):
         self.cube.facts(cuts='cofogXX:"4"')
@@ -70,6 +89,14 @@ class CubeTestCase(TestCase):
         assert 'cofog1.name' in row0, row0
         assert 'amount' not in row0, row0
         assert 'amount.sum' not in row0, row0
+
+    def test_facts_star_fields(self):
+        facts = self.cube.facts(fields='cofog1,cap_or_cur.label')
+        assert facts['total_fact_count'] == 36, facts['total_fact_count']
+        row0 = facts['data'][0]
+        assert 'cofog1.name' in row0, row0
+        assert 'cap_or_cur.code' not in row0, row0
+        assert 'cap_or_cur.label' in row0, row0
 
     @raises(QueryException)
     def test_facts_invalid_field(self):
@@ -96,6 +123,17 @@ class CubeTestCase(TestCase):
         assert 'cofog1.name' in row0, row0
         assert 'amount' not in row0, row0
 
+    def test_members_star_dimension(self):
+        members = self.cube.members('cap_or_cur', order='cap_or_cur.label:asc')
+        assert members['total_member_count'] == 2, members['total_member_count']
+        assert len(members['data']) == 2, len(members['data'])
+        assert 'cap_or_cur.code' in members['data'][0], members['data'][0]
+        assert 'CAP' == members['data'][0]['cap_or_cur.code'], members['data'][0]
+
+    def test_members_star_dimension_order(self):
+        members = self.cube.members('cap_or_cur', order='cap_or_cur.label:desc')
+        assert 'CUR' == members['data'][0]['cap_or_cur.code'], members['data'][0]
+
     def test_members_paginate(self):
         members = self.cube.members('cofog1', page_size=2)
         assert members['total_member_count'] == 4, members['total_member_count']
@@ -109,16 +147,25 @@ class CubeTestCase(TestCase):
 
     def test_aggregate_basic(self):
         aggs = self.cube.aggregate(drilldowns='cofog1')
-        assert aggs['total_cell_count'] == 4, aggs['total_member_count']
+        assert aggs['total_cell_count'] == 4, aggs['total_cell_count']
         assert len(aggs['cells']) == 4, len(aggs['data'])
         row0 = aggs['cells'][0]
         assert 'cofog1.name' in row0, row0
         assert 'amount.sum' in row0, row0
         assert 'amount' not in row0, row0
 
+    def test_aggregate_star(self):
+        aggs = self.cube.aggregate(drilldowns='cap_or_cur', order='cap_or_cur')
+        assert aggs['total_cell_count'] == 2, aggs
+        assert len(aggs['cells']) == 2, len(aggs['data'])
+        row0 = aggs['cells'][0]
+        assert row0['cap_or_cur.code'] == 'CAP', row0
+        assert row0['amount.sum'] == -608400000, row0
+        assert row0['_count'] == 15, row0
+
     def test_aggregate_count_only(self):
         aggs = self.cube.aggregate(drilldowns='cofog1', aggregates='_count')
-        assert aggs['total_cell_count'] == 4, aggs['total_member_count']
+        assert aggs['total_cell_count'] == 4, aggs['total_cell_count']
         assert len(aggs['cells']) == 4, len(aggs['data'])
         assert '_count' in aggs['summary'], aggs['summary']
         row0 = aggs['cells'][0]
@@ -128,7 +175,7 @@ class CubeTestCase(TestCase):
 
     def test_aggregate_empty(self):
         aggs = self.cube.aggregate(drilldowns='cofog1', page_size=0)
-        assert aggs['total_cell_count'] == 4, aggs['total_member_count']
+        assert aggs['total_cell_count'] == 4, aggs['total_cell_count']
         assert len(aggs['cells']) == 0, len(aggs['data'])
 
     def test_compute_cardinalities(self):


### PR DESCRIPTION
Simple star tables support.

No additional tests yet. Only failing test is currently failing in master.

Will change commit messages from WIP and clean up the code, but keen to hear feedback. I'm running a parallel PR against our fork since time is tight for me but the idea is to get this merged upstream and keep our fork consistent with upstream.

join_column should be in the fact_table.
Simple optimisation for listing members of a dimension - it won't join with the fact table if the dimension table is the only one referenced in the query. 

The binding tuples should really become objects, I think.

Assumes referencing a column adds it to q.froms, which seems to be the case from experimentation.
