### PR TITLE
[#1300] Don't stream aggregate's CSV responses

### DIFF
--- a/babbage/api.py
+++ b/babbage/api.py
@@ -4,7 +4,7 @@ from datetime import date
 from decimal import Decimal
 
 from werkzeug.exceptions import NotFound
-from flask import Blueprint, Response, request, current_app, json, url_for
+from flask import Blueprint, Response, request, current_app, json, url_for, make_response
 
 from babbage.exc import BabbageException
 
@@ -77,12 +77,15 @@ def create_csv_response(columns, rows):
             data = [
                 str(row.get(column))
                 for column in columns_to_show
-                ]
+            ]
             yield ','.join(data) + '\n'
 
-    return Response(
-        _generator(), mimetype='text/csv'
-    )
+    data = ''.join([row for row in _generator()])
+
+    response = make_response(data)
+    response.mimetype = 'text/csv'
+
+    return response
 
 
 def url(*a, **kw):


### PR DESCRIPTION
Although it would be very important to stream the response, as CSVs can get big,
we can't do so with our current caching infrastructure that relies on pickling
the responses. Streaming responses can't be pickled.

I've done this change in a way that's trivial to come back to streaming,
whenever our caching infrastructure supports it.

openspending/openspending#1300