### PR TITLE
[#1123] Fix the data returned by aggregate in CSV format

### DIFF
--- a/babbage/api.py
+++ b/babbage/api.py
@@ -81,7 +81,11 @@ def create_csv_response(columns, rows):
             yield ','.join(data) + '\n'
 
     return Response(
-        _generator(), mimetype='text/csv'
+        _generator(),
+        mimetype='text/csv',
+        headers={
+            'Content-disposition': 'attachment; filename="data.csv"'
+        }
     )
 
 

--- a/babbage/api.py
+++ b/babbage/api.py
@@ -64,20 +64,20 @@ def jsonify(obj, status=200, headers=None):
                     mimetype='application/json')
 
 
-def create_csv_response(columns, rows):
+def create_csv_response(rows):
     def _generator():
-        columns_to_show = [
-            column
-            for column in columns
-            if not column.startswith('_')
-        ]
-        yield ','.join(columns_to_show) + '\n'
+        convert_to_str = lambda value: str(value) if value is not None else ''
+        columns = []
 
-        for row in rows:
+        for index, row in enumerate(rows):
+            if index == 0:
+                columns = sorted(row.keys())
+                yield ','.join(columns) + '\n'
+
             data = [
-                str(row.get(column))
-                for column in columns_to_show
-                ]
+                convert_to_str(row.get(column))
+                for column in columns
+            ]
             yield ','.join(data) + '\n'
 
     return Response(
@@ -154,7 +154,7 @@ def aggregate(name):
     result['status'] = 'ok'
 
     if request.args.get('format', '').lower() == 'csv':
-        return create_csv_response(result['aggregates'], result['cells'])
+        return create_csv_response(result['cells'])
     else:
         return jsonify(result)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ def fixtures_cube_manager(sqla_engine):
     path = os.path.join(FIXTURE_PATH, 'models')
     return babbage.manager.JSONCubeManager(sqla_engine, path)
 
+
 @pytest.fixture
 def load_api_fixtures(app, fixtures_cube_manager):
     return babbage.api.configure_api(app, fixtures_cube_manager)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -46,16 +46,46 @@ class TestCubeManager(object):
 
     @pytest.mark.usefixtures('load_fixtures')
     def test_aggregate_returns_csv_format(self, client):
-        res = client.get(url_for('babbage_api.aggregate', name='cra', format='csv'))
+        url = url_for(
+            'babbage_api.aggregate',
+            name='cra',
+            drilldown='cofog1.label',
+            order='cofog1.label',
+            format='csv'
+        )
+        res = client.get(url)
 
         assert res.status_code == 200
         data = res.get_data().decode('utf-8')
         rows = [row for row in csv.DictReader(io.StringIO(data))]
-
-        assert rows == [
-            {'total.sum': '-371500000', 'amount.sum': '-371500000'}
+        expected_rows = [
+            {
+                '_count': '12',
+                'amount.sum': '45400000',
+                'cofog1.label': 'Economic affairs',
+                'total.sum': '45400000'
+            },
+            {
+                '_count': '8',
+                'amount.sum': '-608900000',
+                'cofog1.label': 'Housing and community amenities',
+                'total.sum': '-608900000'
+            },
+            {
+                '_count': '5',
+                'amount.sum': '500000',
+                'cofog1.label': 'Public order and safety',
+                'total.sum': '500000'
+            },
+            {
+                '_count': '11',
+                'amount.sum': '191500000',
+                'cofog1.label': 'Social protection',
+                'total.sum': '191500000'
+            }
         ]
 
+        assert rows == expected_rows
 
     @pytest.mark.usefixtures('load_fixtures')
     def test_aggregate_drilldown(self, client):


### PR DESCRIPTION
**[#1123] Set the default CSV filename to "data.csv"**
Otherwise the default name would be the URL path, in this case "aggregate".

openspending/openspending#1123

**[#1123] Return all cell's columns in the CSV response**
We were returning only the aggregates, like "executed.sum", "approved.sum",
etc., so the user received a bunch of rows without their labels.

openspending/openspending#1123